### PR TITLE
Fix out of source build

### DIFF
--- a/MySQLApp/src/Makefile
+++ b/MySQLApp/src/Makefile
@@ -43,11 +43,9 @@ install:
 	-$(MKDIR) $(TOP)/include
 	-$(MKDIR) $(TOP)/include/mysql
 	-$(MKDIR) $(TOP)/include/mysql/psi
-	-$(MKDIR) $(TOP)/include/cppconn
 	$(CP) -f $(MYSQL_DIR)/include/*.h* $(TOP)/include/
 	$(CP) -f $(MYSQL_DIR)/include/mysql/*.h* $(TOP)/include/mysql/
 	$(CP) -f $(MYSQL_DIR)/include/mysql/psi/*.h* $(TOP)/include/mysql/psi/
-	$(CP) -f $(MYSQL_DIR)/include/cppconn/*.h* $(TOP)/include/cppconn/
 	$(CP) -f $(MYSQL_DIR)/bin/* $(TOP)/bin/$(EPICS_HOST_ARCH)/
 # this directory (on windows) causes cp from lib to fail
 	-$(RMDIR) $(MYSQL_DIR)/lib/debug

--- a/MySQLCPPApp/src/Makefile
+++ b/MySQLCPPApp/src/Makefile
@@ -34,7 +34,7 @@ include $(TOP)/configure/RULES
 
 ifdef T_A
 install:
-	cmake ../mysql-connector-c++ -G "$(CMAKE_GENERATOR)" -DCMAKE_INSTALL_PREFIX:PATH="$(MYSQL_DIR)" $(CMAKE_CONFIG_FLAGS)
+	cmake ../mysql-connector-c++ -G "$(CMAKE_GENERATOR)" -DCMAKE_INSTALL_PREFIX:PATH="$(MYSQL_DIR)" -DMYSQL_DIR:PATH="$(MYSQL_DIR)" $(CMAKE_CONFIG_FLAGS)
 	cmake --build . --target install --config $(CMAKE_CONFIG) $(CMAKE_BUILD_FLAGS)
 	-$(MKDIR) $(TOP)/bin
 	-$(MKDIR) $(TOP)/bin/$(EPICS_HOST_ARCH)


### PR DESCRIPTION
With out of source builds, need to pass MYSQL_DIR to CPP configuration or else it can pick up MySQL installed on build computer and get errors...